### PR TITLE
Enhance stopped session cards with cwd display and markdown output

### DIFF
--- a/routes.ts
+++ b/routes.ts
@@ -142,6 +142,7 @@ export function createRoutes(
         const items = [...stoppedSessions.values()].map(({ sessionId, stoppedAt, transcriptPath, payload }) => ({
           sessionId, stoppedAt, transcriptPath,
           terminal_info: payload.terminal_info,
+          cwd: payload.cwd,
         }))
         return Response.json(items)
       },

--- a/ui-types.ts
+++ b/ui-types.ts
@@ -3,6 +3,7 @@ export interface StoppedSession {
   stoppedAt: number
   transcriptPath?: string
   terminal_info?: TerminalInfo
+  cwd?: string
 }
 
 export interface TerminalInfo {

--- a/ui.html
+++ b/ui.html
@@ -317,7 +317,6 @@
       font-size: 0.8rem;
       color: #94a3b8;
       line-height: 1.55;
-      white-space: pre-wrap;
       word-break: break-word;
       max-height: 200px;
       overflow-y: auto;
@@ -325,6 +324,10 @@
       padding: 0.4rem 0.75rem;
       margin-bottom: 0.75rem;
     }
+    .stopped-output p { margin-bottom: 0.4rem; }
+    .stopped-output p:last-child { margin-bottom: 0; }
+    .stopped-output ul, .stopped-output ol { margin: 0.25rem 0 0.4rem 1.1rem; }
+    .stopped-output code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.8em; background: #0f1117; padding: 0.1em 0.3em; border-radius: 3px; }
     .btn-dismiss { background: transparent; color: #64748b; border: 1px solid #2d3548; }
     .btn-dismiss:hover { color: #94a3b8; border-color: #475569; }
 

--- a/ui.ts
+++ b/ui.ts
@@ -398,14 +398,17 @@ function makeStoppedCard(session: StoppedSession): HTMLElement {
   const when = new Date(session.stoppedAt).toLocaleTimeString()
   const ti = session.terminal_info
   const hasFocusTarget = !!(ti?.iterm_session_id || ti?.ghostty_resources_dir || ti?.term_program)
+  const cwdShort = shortCwd(session.cwd ?? '')
+  const cwdFull = session.cwd ?? ''
 
   card.innerHTML = `
     <div class="card-header">
       <span class="badge badge-stopped">Finished</span>
+      ${cwdShort ? `<span class="cwd" title="${cwdFull}">${cwdShort}</span>` : ''}
       <span class="session">${sid}</span>
     </div>
     <div class="stopped-time">${when}</div>
-    <div class="stopped-output"></div>
+    <div class="stopped-output" style="display:block">Loading…</div>
     <div class="actions">
       <button class="btn-dismiss">Dismiss</button>
       <button class="btn-focus"${hasFocusTarget ? '' : ' style="display:none"'}>Focus</button>
@@ -413,15 +416,21 @@ function makeStoppedCard(session: StoppedSession): HTMLElement {
   `
 
   const outputEl = card.querySelector<HTMLElement>('.stopped-output')!
-  fetch(`/stopped/${session.sessionId}/output`)
-    .then(r => r.json())
-    .then((body: { output?: string; error?: string }) => {
-      if (body.output) {
-        outputEl.textContent = body.output
-        outputEl.style.display = ''
-      }
-    })
-    .catch(() => {})
+
+  if (!session.transcriptPath) {
+    outputEl.textContent = 'No transcript available'
+  } else {
+    fetch(`/stopped/${session.sessionId}/output`)
+      .then(r => r.json())
+      .then((body: { output?: string; error?: string }) => {
+        if (body.output) {
+          outputEl.innerHTML = marked.parse(body.output) as string
+        } else {
+          outputEl.textContent = 'No output available'
+        }
+      })
+      .catch(() => { outputEl.textContent = 'Failed to load output' })
+  }
 
   card.querySelector('.btn-dismiss')!.addEventListener('click', async () => {
     await fetch(`/stopped/${session.sessionId}`, { method: 'DELETE' })


### PR DESCRIPTION
## Summary
This PR improves the display of stopped session information by adding current working directory (cwd) display to session cards and enhancing output rendering with markdown support.

## Key Changes
- **Added cwd field to StoppedSession interface** - Now tracks and displays the working directory where sessions were running
- **Display cwd in session card header** - Shows a shortened version of the cwd with full path available on hover
- **Enhanced output rendering** - Switched from plain text to markdown parsing using the `marked` library for better formatted output
- **Improved error handling** - Added specific messages for different output states (no transcript, no output, failed to load)
- **Added markdown-aware styling** - New CSS rules for proper rendering of markdown elements (paragraphs, lists, code blocks) within the output section
- **Backend integration** - Updated the stopped sessions endpoint to include the `cwd` field from session payload

## Implementation Details
- The `shortCwd()` function is used to display a user-friendly version of the working directory path
- Output loading state now shows "Loading…" initially instead of being empty
- Markdown output is parsed and rendered as HTML, with appropriate styling for code blocks, lists, and paragraphs
- The output section maintains its max-height and scrolling behavior for long content
- Removed `white-space: pre-wrap` from output styling to allow proper markdown rendering

https://claude.ai/code/session_01BUK61X4cuPGe7KmFnbuwXJ