### PR TITLE
Auto-clear stale pending entries on session stop and new activity

### DIFF
--- a/routes.test.ts
+++ b/routes.test.ts
@@ -139,6 +139,43 @@ describe('POST /pending + POST /decide/:id', () => {
     await bashRes
   })
 
+  test('auto-clears stale non-AskUserQuestion entries on new session activity', async () => {
+    // Enqueue a Bash entry (simulating a CLI-denied tool that left a stale entry)
+    const bashRes = fetch(`http://localhost:${server.port}/pending`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'rm -rf /' }, session_id: 'sessA' }),
+    })
+
+    await Bun.sleep(10)
+    expect(pending.size).toBe(1)
+
+    // Next tool from same session clears the stale Bash entry and adds new one
+    const writeRes = fetch(`http://localhost:${server.port}/pending`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tool_name: 'Write', tool_input: { path: '/tmp/x' }, session_id: 'sessA' }),
+    })
+
+    await Bun.sleep(10)
+    expect(pending.size).toBe(1)
+    const [[, entry]] = [...pending.entries()]
+    expect(entry.payload.tool_name).toBe('Write')
+
+    // Stale Bash entry was resolved with deny
+    const bashBody = await bashRes.then(r => r.json()) as { hookSpecificOutput: { decision: { behavior: string } } }
+    expect(bashBody.hookSpecificOutput.decision.behavior).toBe('deny')
+
+    // Resolve the Write entry to clean up
+    const [[writeId]] = [...pending.entries()]
+    await fetch(`http://localhost:${server.port}/decide/${writeId}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ decision: 'allow' }),
+    })
+    await writeRes
+  })
+
   test('404 on unknown id', async () => {
     const res = await fetch(`http://localhost:${server.port}/decide/no-such-id`, {
       method: 'POST',
@@ -146,6 +183,69 @@ describe('POST /pending + POST /decide/:id', () => {
       body: JSON.stringify({ decision: 'allow' }),
     })
     expect(res.status).toBe(404)
+  })
+})
+
+describe('POST /stop', () => {
+  let server: ReturnType<typeof Bun.serve>
+  let pending: Map<string, PendingEntry>
+  let stopped: Map<string, StoppedSession>
+
+  beforeEach(() => {
+    ({ server, pending, stopped } = makeServer())
+  })
+  afterEach(() => server.stop(true))
+
+  test('clears pending entries for the stopped session', async () => {
+    const pendingRes = fetch(`http://localhost:${server.port}/pending`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'echo hi' }, session_id: 'sessStop' }),
+    })
+
+    await Bun.sleep(10)
+    expect(pending.size).toBe(1)
+
+    await fetch(`http://localhost:${server.port}/stop`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ session_id: 'sessStop' }),
+    })
+
+    expect(pending.size).toBe(0)
+    expect(stopped.has('sessStop')).toBe(true)
+
+    // Stale pending entry was resolved with deny
+    const body = await pendingRes.then(r => r.json()) as { hookSpecificOutput: { decision: { behavior: string } } }
+    expect(body.hookSpecificOutput.decision.behavior).toBe('deny')
+  })
+
+  test('does not clear pending entries from other sessions', async () => {
+    const pendingRes = fetch(`http://localhost:${server.port}/pending`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'echo hi' }, session_id: 'sessOther' }),
+    })
+
+    await Bun.sleep(10)
+    expect(pending.size).toBe(1)
+
+    await fetch(`http://localhost:${server.port}/stop`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ session_id: 'sessDifferent' }),
+    })
+
+    expect(pending.size).toBe(1)
+
+    // Resolve to clean up
+    const [[id]] = [...pending.entries()]
+    await fetch(`http://localhost:${server.port}/decide/${id}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ decision: 'allow' }),
+    })
+    await pendingRes
   })
 })
 

--- a/routes.ts
+++ b/routes.ts
@@ -133,6 +133,14 @@ export function createRoutes(
         const transcriptPath = payload.transcript_path as string | undefined
         stoppedSessions.set(sessionId, { sessionId, stoppedAt: Date.now(), transcriptPath, payload })
         console.log(`[stop] session=${sessionId}`)
+        // Clear any pending entries for this session (e.g. last tool was CLI-denied)
+        for (const [pendingId, entry] of pending) {
+          if (entry.payload.session_id === sessionId) {
+            logRemoval(pendingId, 'session-stopped', entry)
+            pending.delete(pendingId)
+            entry.resolve('deny')
+          }
+        }
         return Response.json({ ok: true })
       },
     },
@@ -206,14 +214,15 @@ export function createRoutes(
           resolveDecision = resolve
         })
 
-        // Auto-resolve any lingering AskUserQuestion entries for this session
+        // Auto-resolve any lingering entries for this session (e.g. previous tool was CLI-denied)
         const incomingSession = payload.session_id as string | undefined
         if (incomingSession) {
           for (const [pendingId, entry] of pending) {
-            if (entry.payload.session_id === incomingSession && entry.payload.tool_name === 'AskUserQuestion') {
-              logRemoval(pendingId, 'new-session-activity', entry)
+            if (entry.payload.session_id === incomingSession) {
+              const isAskQuestion = entry.payload.tool_name === 'AskUserQuestion'
+              logRemoval(pendingId, isAskQuestion ? 'new-session-activity' : 'cli-denied', entry)
               pending.delete(pendingId)
-              entry.resolve('allow')
+              entry.resolve(isAskQuestion ? 'allow' : 'deny')
             }
           }
         }


### PR DESCRIPTION
## Summary
This PR improves session cleanup by automatically resolving stale pending tool entries when a session stops or when new activity arrives from an existing session. This prevents CLI-denied tools from blocking subsequent operations.

## Key Changes
- **Session stop handler**: When `/stop` is called, all pending entries for that session are now cleared and resolved with a 'deny' decision
- **New session activity handler**: Expanded the auto-clear logic to handle non-AskUserQuestion entries (e.g., CLI-denied tools) in addition to AskUserQuestion entries
  - Non-AskUserQuestion entries are resolved with 'deny' (representing the original CLI denial)
  - AskUserQuestion entries continue to be resolved with 'allow' (existing behavior)
- **Improved logging**: Updated removal reason labels to distinguish between 'new-session-activity' (for AskUserQuestion) and 'cli-denied' (for other tool types)

## Implementation Details
- Both the `/stop` endpoint and the `/pending` POST handler now iterate through pending entries to find matches by `session_id`
- The logic differentiates between entry types to apply appropriate resolution behavior
- Stale entries are properly logged before removal for debugging purposes

https://claude.ai/code/session_01DNdr4UBo6sMCp64rtd2zc7