### PR TITLE
Add session start hook and Claude Code Web documentation

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in Claude Code Web (remote) sessions
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# Install dependencies
+bun install

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,18 @@ This is a Claude Code approval server. It intercepts Claude's `PermissionRequest
 - The `PostToolUse` hook fires after the user approves from the CLI, allowing stale pending items to self-clear via `/post-tool-use`
 - `AskUserQuestion` cards auto-clear when the next tool call from the same session arrives
 
+## Documentation
+
+Keep `README.md` up to date whenever you make changes that affect:
+- How the server works or what it does
+- Setup / installation steps
+- Hook configuration
+- New features or removed features
+
+## Claude Code Web
+
+When running in Claude Code Web (`$CLAUDE_CODE_REMOTE=true`), take screenshots of the UI at `http://localhost:4759` and include them in pull request descriptions. Start the server with `bun index.ts &` before taking screenshots, then kill it after. Use the screenshot tool to capture the UI and embed the images in the PR body.
+
 Default to using Bun instead of Node.js.
 
 - Use `bun <file>` instead of `node <file>` or `ts-node <file>`


### PR DESCRIPTION
## Summary
This PR adds automated dependency installation for Claude Code Web sessions and updates documentation with guidelines for maintaining the project and working with Claude Code Web.

## Key Changes
- **Added `.claude/settings.json`**: Configures a `SessionStart` hook that automatically runs when a Claude Code Web session begins
- **Added `.claude/hooks/session-start.sh`**: Hook script that runs `bun install` to install dependencies when the server starts in Claude Code Web (`$CLAUDE_CODE_REMOTE=true`). The script safely exits if not running in a remote session.
- **Updated `CLAUDE.md`**: Added two new documentation sections:
  - **Documentation**: Guidelines for keeping `README.md` up to date with changes to server functionality, setup steps, hooks, and features
  - **Claude Code Web**: Instructions for testing the server in Claude Code Web, including taking screenshots of the UI at `http://localhost:4759` and embedding them in PR descriptions

## Implementation Details
- The session start hook only executes in Claude Code Web environments (when `$CLAUDE_CODE_REMOTE=true`), preventing unnecessary runs in local development
- Uses `set -euo pipefail` for robust error handling in the bash script
- Ensures dependencies are automatically available when the server starts in Claude Code Web, improving the developer experience

https://claude.ai/code/session_01FQrFafBeVw1sevuH7M1JP2