### PR TITLE
feat: add favicon with dynamic state indicator and GitHub link in settings

### DIFF
--- a/frontend/app/components/settings-modal.gts
+++ b/frontend/app/components/settings-modal.gts
@@ -113,6 +113,12 @@ export default class SettingsModal extends Component {
             </label>
           </div>
           <div id="settings-footer">
+            <a
+              class="settings-repo-link"
+              href="https://github.com/wagenet/claude-approval-server"
+              target="_blank"
+              rel="noopener noreferrer"
+            >Contribute on GitHub</a>
             <button
               type="button"
               class="btn-deny"

--- a/frontend/app/services/approval-queue.ts
+++ b/frontend/app/services/approval-queue.ts
@@ -2,10 +2,12 @@ import Service, { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import type { QueueItem, IdleSession } from '../utils/ui-types';
 import type AppSettingsService from './app-settings';
+import type FaviconService from './favicon';
 import { shortCwd, SESSION_COLORS } from '../utils/ui-utils';
 
 export default class ApprovalQueueService extends Service {
   @service declare appSettings: AppSettingsService;
+  @service declare favicon: FaviconService;
 
   @tracked items: QueueItem[] = [];
   @tracked idleSessions: IdleSession[] = [];
@@ -108,6 +110,8 @@ export default class ApprovalQueueService extends Service {
         this.idleSessions = sessions;
       }
     }
+
+    this.favicon.update();
   }
 
   #notify(title: string, body: string, opts: NotificationOptions = {}) {

--- a/frontend/app/services/favicon.ts
+++ b/frontend/app/services/favicon.ts
@@ -1,0 +1,88 @@
+import Service, { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import type ApprovalQueueService from './approval-queue';
+
+type FaviconState = 'idle' | 'pending' | 'offline';
+
+const SHIELD_OPEN =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">' +
+  '<path d="M16 2 L4 7 L4 15 C4 22.7 9.3 29.4 16 31 C22.7 29.4 28 22.7 28 15 L28 7 Z" fill="#1e2330" stroke="STROKE" stroke-width="1.5"/>';
+const SHIELD_CLOSE = '</svg>';
+
+const ICON_IDLE =
+  '<polyline points="10,16 14,20 22,12" fill="none" stroke="#22c55e" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>';
+
+const ICON_PENDING =
+  '<circle cx="16" cy="14" r="2" fill="#f59e0b"/>' +
+  '<rect x="15" y="17" width="2" height="5" rx="1" fill="#f59e0b"/>';
+
+const ICON_OFFLINE =
+  '<line x1="11" y1="11" x2="21" y2="21" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round"/>' +
+  '<line x1="21" y1="11" x2="11" y2="21" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round"/>';
+
+const STROKE_MAP: Record<FaviconState, string> = {
+  idle: '#38bdf8',
+  pending: '#f59e0b',
+  offline: '#ef4444',
+};
+
+const ICON_MAP: Record<FaviconState, string> = {
+  idle: ICON_IDLE,
+  pending: ICON_PENDING,
+  offline: ICON_OFFLINE,
+};
+
+function buildSvg(state: FaviconState): string {
+  const stroke = STROKE_MAP[state];
+  const icon = ICON_MAP[state];
+  return SHIELD_OPEN.replace('STROKE', stroke) + icon + SHIELD_CLOSE;
+}
+
+function svgToDataUrl(svg: string): string {
+  return 'data:image/svg+xml,' + encodeURIComponent(svg);
+}
+
+export default class FaviconService extends Service {
+  @service declare approvalQueue: ApprovalQueueService;
+
+  @tracked currentState: FaviconState = 'idle';
+  #interval?: ReturnType<typeof setInterval>;
+  #linkEl?: HTMLLinkElement;
+
+  start() {
+    const el = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+    this.#linkEl = el ?? undefined;
+    this.#update();
+    this.#interval = setInterval(() => this.#update(), 1000);
+  }
+
+  #update() {
+    const next = this.#deriveState();
+    if (next === this.currentState) return;
+    this.currentState = next;
+    this.#applyFavicon(next);
+  }
+
+  #deriveState(): FaviconState {
+    if (this.approvalQueue.isOffline) return 'offline';
+    const nonSnoozed = this.approvalQueue.items.filter(
+      (i) => !i.snoozedToDesktop
+    );
+    if (nonSnoozed.length > 0) return 'pending';
+    return 'idle';
+  }
+
+  #applyFavicon(state: FaviconState) {
+    if (!this.#linkEl) return;
+    if (state === 'idle') {
+      this.#linkEl.href = '/favicon.svg';
+    } else {
+      this.#linkEl.href = svgToDataUrl(buildSvg(state));
+    }
+  }
+
+  willDestroy() {
+    super.willDestroy();
+    clearInterval(this.#interval);
+  }
+}

--- a/frontend/app/services/favicon.ts
+++ b/frontend/app/services/favicon.ts
@@ -1,88 +1,72 @@
 import Service, { service } from '@ember/service';
-import { tracked } from '@glimmer/tracking';
 import type ApprovalQueueService from './approval-queue';
 
 type FaviconState = 'idle' | 'pending' | 'offline';
 
-const SHIELD_OPEN =
-  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">' +
-  '<path d="M16 2 L4 7 L4 15 C4 22.7 9.3 29.4 16 31 C22.7 29.4 28 22.7 28 15 L28 7 Z" fill="#1e2330" stroke="STROKE" stroke-width="1.5"/>';
-const SHIELD_CLOSE = '</svg>';
-
-const ICON_IDLE =
-  '<polyline points="10,16 14,20 22,12" fill="none" stroke="#22c55e" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>';
-
-const ICON_PENDING =
-  '<circle cx="16" cy="14" r="2" fill="#f59e0b"/>' +
-  '<rect x="15" y="17" width="2" height="5" rx="1" fill="#f59e0b"/>';
-
-const ICON_OFFLINE =
-  '<line x1="11" y1="11" x2="21" y2="21" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round"/>' +
-  '<line x1="21" y1="11" x2="11" y2="21" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round"/>';
-
-const STROKE_MAP: Record<FaviconState, string> = {
-  idle: '#38bdf8',
-  pending: '#f59e0b',
-  offline: '#ef4444',
-};
-
-const ICON_MAP: Record<FaviconState, string> = {
-  idle: ICON_IDLE,
-  pending: ICON_PENDING,
-  offline: ICON_OFFLINE,
-};
-
-function buildSvg(state: FaviconState): string {
-  const stroke = STROKE_MAP[state];
-  const icon = ICON_MAP[state];
-  return SHIELD_OPEN.replace('STROKE', stroke) + icon + SHIELD_CLOSE;
+function buildShieldSvg(stroke: string, icon: string): string {
+  return (
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">' +
+    `<path d="M16 2 L4 7 L4 15 C4 22.7 9.3 29.4 16 31 C22.7 29.4 28 22.7 28 15 L28 7 Z" fill="#1e2330" stroke="${stroke}" stroke-width="1.5"/>` +
+    icon +
+    '</svg>'
+  );
 }
 
-function svgToDataUrl(svg: string): string {
-  return 'data:image/svg+xml,' + encodeURIComponent(svg);
-}
+const PENDING_DATA_URL =
+  'data:image/svg+xml,' +
+  encodeURIComponent(
+    buildShieldSvg(
+      '#f59e0b',
+      '<circle cx="16" cy="14" r="2" fill="#f59e0b"/>' +
+        '<rect x="15" y="17" width="2" height="5" rx="1" fill="#f59e0b"/>'
+    )
+  );
+
+const OFFLINE_DATA_URL =
+  'data:image/svg+xml,' +
+  encodeURIComponent(
+    buildShieldSvg(
+      '#ef4444',
+      '<line x1="11" y1="11" x2="21" y2="21" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round"/>' +
+        '<line x1="21" y1="11" x2="11" y2="21" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round"/>'
+    )
+  );
+
+const FAVICON_HREFS: Record<FaviconState, string> = {
+  idle: '', // filled at runtime with original href
+  pending: PENDING_DATA_URL,
+  offline: OFFLINE_DATA_URL,
+};
 
 export default class FaviconService extends Service {
   @service declare approvalQueue: ApprovalQueueService;
 
-  @tracked currentState: FaviconState = 'idle';
-  #interval?: ReturnType<typeof setInterval>;
+  #currentState: FaviconState = 'idle';
   #linkEl?: HTMLLinkElement;
+  #originalHref?: string;
+  #started = false;
 
   start() {
+    if (this.#started) return;
+    this.#started = true;
     const el = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
     this.#linkEl = el ?? undefined;
-    this.#update();
-    this.#interval = setInterval(() => this.#update(), 1000);
+    this.#originalHref = el?.href;
   }
 
-  #update() {
+  update() {
     const next = this.#deriveState();
-    if (next === this.currentState) return;
-    this.currentState = next;
-    this.#applyFavicon(next);
+    if (next === this.#currentState) return;
+    this.#currentState = next;
+    if (!this.#linkEl) return;
+    this.#linkEl.href =
+      next === 'idle' ? (this.#originalHref ?? '') : FAVICON_HREFS[next];
   }
 
   #deriveState(): FaviconState {
     if (this.approvalQueue.isOffline) return 'offline';
-    const nonSnoozed = this.approvalQueue.items.filter(
-      (i) => !i.snoozedToDesktop
-    );
-    if (nonSnoozed.length > 0) return 'pending';
+    if (this.approvalQueue.items.some((i) => !i.snoozedToDesktop))
+      return 'pending';
     return 'idle';
-  }
-
-  #applyFavicon(state: FaviconState) {
-    if (!this.#linkEl) return;
-    if (state === 'idle') {
-      this.#linkEl.href = '/favicon.svg';
-    } else {
-      this.#linkEl.href = svgToDataUrl(buildSvg(state));
-    }
-  }
-
-  willDestroy() {
-    super.willDestroy();
-    clearInterval(this.#interval);
   }
 }

--- a/frontend/app/styles/app.css
+++ b/frontend/app/styles/app.css
@@ -1007,8 +1007,20 @@ button:active {
   padding: 1rem 1.5rem;
   border-top: 1px solid var(--border);
   display: flex;
-  justify-content: flex-end;
+  align-items: center;
   gap: 0.625rem;
+}
+
+.settings-repo-link {
+  margin-right: auto;
+  font-size: 0.78rem;
+  color: var(--text-timer);
+  text-decoration: none;
+}
+
+.settings-repo-link:hover {
+  color: var(--text-muted);
+  text-decoration: underline;
 }
 
 /* stylelint-disable selector-class-pattern -- highlight.js uses non-kebab class names */

--- a/frontend/app/templates/application.gts
+++ b/frontend/app/templates/application.gts
@@ -17,8 +17,8 @@ export default class ApplicationTemplate extends Component {
 
   constructor(owner: Owner, args: object) {
     super(owner, args);
-    void this.approvalQueue.start();
     this.favicon.start();
+    void this.approvalQueue.start();
     const reportVisibility = () => {
       void fetch('/window-activity', {
         method: 'POST',

--- a/frontend/app/templates/application.gts
+++ b/frontend/app/templates/application.gts
@@ -8,14 +8,17 @@ import PlanModal from '../components/plan-modal';
 import SettingsModal from '../components/settings-modal';
 import type ApprovalQueueService from '../services/approval-queue';
 import type AppSettingsService from '../services/app-settings';
+import type FaviconService from '../services/favicon';
 
 export default class ApplicationTemplate extends Component {
   @service declare approvalQueue: ApprovalQueueService;
   @service declare appSettings: AppSettingsService;
+  @service declare favicon: FaviconService;
 
   constructor(owner: Owner, args: object) {
     super(owner, args);
     void this.approvalQueue.start();
+    this.favicon.start();
     const reportVisibility = () => {
       void fetch('/window-activity', {
         method: 'POST',

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,6 +6,8 @@
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+
     {{content-for "head"}}
 
     <link integrity="" rel="stylesheet" href="/@embroider/virtual/vendor.css">

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M16 2 L4 7 L4 15 C4 22.7 9.3 29.4 16 31 C22.7 29.4 28 22.7 28 15 L28 7 Z" fill="#1e2330" stroke="#38bdf8" stroke-width="1.5"/>
+  <polyline points="10,16 14,20 22,12" fill="none" stroke="#22c55e" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Summary

- **Favicon**: Adds an SVG favicon (shield + checkmark) so the tab is no longer a blank generic icon
- **Dynamic favicon**: A `FaviconService` polls queue state every second and swaps the favicon to reflect the current app state — green checkmark (idle/all clear), amber exclamation (pending items need attention), or red X (server offline). Works like GitHub Actions showing pass/fail in the browser tab.
- **GitHub link**: Adds a "Contribute on GitHub" link in the settings modal footer, pointing to the repo so users can easily find and contribute to the project

<img width="546" height="289" alt="Screenshot 2026-03-30 at 8 22 13 PM" src="https://github.com/user-attachments/assets/e2e586f3-41c6-42c6-b702-f252f8e7a361" />
<img width="63" height="41" alt="Screenshot 2026-03-30 at 8 20 30 PM" src="https://github.com/user-attachments/assets/2b398196-4ab9-4390-b7fd-652dec08e198" />
<img width="76" height="52" alt="Screenshot 2026-03-30 at 8 20 25 PM" src="https://github.com/user-attachments/assets/812d15f4-82c7-49f9-9355-6a6c21b30e97" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)