### PR TITLE
feat: session history modal for idle sessions

### DIFF
--- a/frontend/app/components/idle-session-card.gts
+++ b/frontend/app/components/idle-session-card.gts
@@ -12,7 +12,7 @@ import type { IdleSession } from '../utils/ui-types';
 import type ApprovalQueueService from '../services/approval-queue';
 
 interface Sig {
-  Args: { session: IdleSession };
+  Args: { session: IdleSession; onOpenHistory: () => void };
 }
 
 export default class IdleSessionCard extends Component<Sig> {
@@ -124,6 +124,9 @@ export default class IdleSessionCard extends Component<Sig> {
       </div>
 
       <div class="actions">
+        <button type="button" class="btn-history" {{on "click" @onOpenHistory}}>
+          History
+        </button>
         <button
           type="button"
           class="btn-dismiss"

--- a/frontend/app/components/idle-sessions.gts
+++ b/frontend/app/components/idle-sessions.gts
@@ -1,8 +1,12 @@
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
+import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import IdleSessionCard from './idle-session-card';
+import SessionHistoryModal from './session-history-modal';
 import type ApprovalQueueService from '../services/approval-queue';
+import type { IdleSession } from '../utils/ui-types';
 import AnimatedEach from 'ember-animated/components/animated-each';
 import { fadeIn, fadeOut } from 'ember-animated/motions/opacity';
 import move from 'ember-animated/motions/move';
@@ -26,10 +30,24 @@ function* cardTransition({
 export default class IdleSessions extends Component {
   @service declare approvalQueue: ApprovalQueueService;
 
+  @tracked historyTarget: { sessionId: string; sessionName: string } | null =
+    null;
+
   cardTransition = cardTransition;
 
   dismissAll = () => {
     void this.approvalQueue.dismissAllIdle();
+  };
+
+  openHistory = (session: IdleSession) => {
+    this.historyTarget = {
+      sessionId: session.sessionId,
+      sessionName: session.sessionName ?? session.sessionId.slice(0, 8) + '…',
+    };
+  };
+
+  closeHistory = () => {
+    this.historyTarget = null;
   };
 
   get normalSessions() {
@@ -69,7 +87,10 @@ export default class IdleSessions extends Component {
             duration=200
             as |session|
           }}
-            <IdleSessionCard @session={{session}} />
+            <IdleSessionCard
+              @session={{session}}
+              @onOpenHistory={{fn this.openHistory session}}
+            />
           {{/AnimatedEach}}
         </div>
       {{else}}
@@ -87,11 +108,22 @@ export default class IdleSessions extends Component {
               duration=200
               as |session|
             }}
-              <IdleSessionCard @session={{session}} />
+              <IdleSessionCard
+                @session={{session}}
+                @onOpenHistory={{fn this.openHistory session}}
+              />
             {{/AnimatedEach}}
           </div>
         </div>
       {{/if}}
     </div>
+
+    {{#if this.historyTarget}}
+      <SessionHistoryModal
+        @sessionId={{this.historyTarget.sessionId}}
+        @sessionName={{this.historyTarget.sessionName}}
+        @onClose={{this.closeHistory}}
+      />
+    {{/if}}
   </template>
 }

--- a/frontend/app/components/session-history-modal.gts
+++ b/frontend/app/components/session-history-modal.gts
@@ -1,0 +1,204 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+import type Owner from '@ember/owner';
+import { formatToolName, badgeClass as getBadgeClass } from '../utils/ui-utils';
+import type { RunLogEntry, QueueItem } from '../utils/ui-types';
+import CodeBlock from './code-block';
+
+interface Sig {
+  Args: {
+    sessionId: string;
+    sessionName?: string;
+    onClose: () => void;
+  };
+}
+
+interface DisplayEntry {
+  entry: RunLogEntry;
+  key: string;
+  time: string;
+  badgeCls: string;
+  toolLabel: string;
+  sourceLabel: string;
+  queueItem: QueueItem;
+}
+
+const REVIEWED_KEY = 'cas:reviewed';
+
+function loadReviewed(): ReadonlySet<string> {
+  try {
+    const raw = localStorage.getItem(REVIEWED_KEY);
+    return new Set(raw ? (JSON.parse(raw) as string[]) : []);
+  } catch {
+    return new Set();
+  }
+}
+
+function saveReviewed(keys: ReadonlySet<string>): void {
+  try {
+    localStorage.setItem(REVIEWED_KEY, JSON.stringify([...keys]));
+  } catch {
+    // storage quota exceeded or private browsing — ignore
+  }
+}
+
+function entryKey(entry: RunLogEntry): string {
+  return `${entry.session_id}:${entry.timestamp}`;
+}
+
+function isReviewed(key: string, reviewedKeys: ReadonlySet<string>): boolean {
+  return reviewedKeys.has(key);
+}
+
+export default class SessionHistoryModal extends Component<Sig> {
+  @tracked displayEntries: DisplayEntry[] = [];
+  @tracked isLoading = true;
+  @tracked error: string | null = null;
+  @tracked reviewedKeys: ReadonlySet<string> = loadReviewed();
+  @tracked hideReviewed = false;
+
+  constructor(owner: Owner, args: Sig['Args']) {
+    super(owner, args);
+    void this.loadHistory();
+  }
+
+  get visibleEntries(): DisplayEntry[] {
+    if (!this.hideReviewed) return this.displayEntries;
+    return this.displayEntries.filter((d) => !this.reviewedKeys.has(d.key));
+  }
+
+  get reviewedCount(): number {
+    return this.displayEntries.filter((d) => this.reviewedKeys.has(d.key))
+      .length;
+  }
+
+  async loadHistory() {
+    try {
+      const resp = await fetch(
+        `/log?session_id=${encodeURIComponent(this.args.sessionId)}`
+      );
+      // SAFETY: /log always returns a JSON array; tool_input is an object on the wire
+      // even though LogEntry.tool_input is typed as unknown on the server.
+      const entries = (await resp.json()) as RunLogEntry[];
+      this.displayEntries = [...entries].reverse().map((entry) => ({
+        entry,
+        key: entryKey(entry),
+        time: new Date(entry.timestamp).toLocaleTimeString(),
+        badgeCls: `badge ${getBadgeClass(entry.tool_name)}`,
+        toolLabel: formatToolName(entry.tool_name),
+        sourceLabel: entry.source === 'auto' ? 'Auto' : 'Approved',
+        queueItem: {
+          id: entryKey(entry),
+          enqueuedAt: entry.timestamp,
+          tool_name: entry.tool_name,
+          // SAFETY: tool_input is always a JSON object at this boundary
+          tool_input: entry.tool_input as Record<string, unknown>,
+          session_id: entry.session_id,
+        },
+      }));
+    } catch {
+      this.error = 'Failed to load history.';
+    } finally {
+      this.isLoading = false;
+    }
+  }
+
+  toggleReviewed = (key: string) => {
+    const next = new Set(this.reviewedKeys);
+    if (next.has(key)) {
+      next.delete(key);
+    } else {
+      next.add(key);
+    }
+    saveReviewed(next);
+    this.reviewedKeys = next;
+  };
+
+  toggleHideReviewed = () => {
+    this.hideReviewed = !this.hideReviewed;
+  };
+
+  backdropClick = (e: MouseEvent) => {
+    if (e.target === e.currentTarget) this.args.onClose();
+  };
+
+  <template>
+    {{! template-lint-disable no-invalid-interactive }}
+    <div class="history-modal" role="dialog" {{on "click" this.backdropClick}}>
+      {{! template-lint-enable no-invalid-interactive }}
+      <div class="history-modal-inner">
+        <div class="history-modal-header">
+          <span class="history-modal-title">
+            Session history{{#if @sessionName}} — {{@sessionName}}{{/if}}
+          </span>
+          {{#if this.reviewedCount}}
+            <button
+              type="button"
+              class="btn-hide-reviewed"
+              {{on "click" this.toggleHideReviewed}}
+            >
+              {{if this.hideReviewed "Show" "Hide"}}
+              reviewed ({{this.reviewedCount}})
+            </button>
+          {{/if}}
+          <button
+            type="button"
+            class="history-modal-close"
+            {{on "click" @onClose}}
+          >Close</button>
+        </div>
+        <div class="history-modal-body">
+          {{#if this.isLoading}}
+            <div class="history-loading">Loading…</div>
+          {{else if this.error}}
+            <div class="history-error">{{this.error}}</div>
+          {{else if this.visibleEntries.length}}
+            {{#each this.visibleEntries as |d|}}
+              <div
+                class={{if
+                  (isReviewed d.key this.reviewedKeys)
+                  "history-entry is-reviewed"
+                  "history-entry"
+                }}
+              >
+                <div class="history-entry-meta">
+                  <span class={{d.badgeCls}}>{{d.toolLabel}}</span>
+                  <span
+                    class="history-entry-source history-source-{{d.entry.source}}"
+                  >{{d.sourceLabel}}</span>
+                  <span class="history-entry-time">{{d.time}}</span>
+                  <button
+                    type="button"
+                    class={{if
+                      (isReviewed d.key this.reviewedKeys)
+                      "btn-mark-reviewed is-reviewed"
+                      "btn-mark-reviewed"
+                    }}
+                    title={{if
+                      (isReviewed d.key this.reviewedKeys)
+                      "Mark unreviewed"
+                      "Mark reviewed"
+                    }}
+                    {{on "click" (fn this.toggleReviewed d.key)}}
+                  >✓</button>
+                </div>
+                <CodeBlock @item={{d.queueItem}} />
+              </div>
+            {{/each}}
+          {{else if this.displayEntries.length}}
+            <div class="history-empty">All entries hidden.
+              <button
+                type="button"
+                class="btn-link"
+                {{on "click" this.toggleHideReviewed}}
+              >Show reviewed.</button></div>
+          {{else}}
+            <div class="history-empty">No history recorded for this session.</div>
+          {{/if}}
+        </div>
+      </div>
+    </div>
+  </template>
+}

--- a/frontend/app/styles/app.css
+++ b/frontend/app/styles/app.css
@@ -388,6 +388,215 @@ h1 .dot {
   margin-left: auto;
 }
 
+/* ── History modal ─────────────────────────────────────── */
+
+.history-modal {
+  position: fixed;
+  inset: 0;
+  background: rgb(0 0 0 / 75%);
+  z-index: 100;
+  padding: 2rem;
+  overflow-y: auto;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+}
+
+.history-modal-inner {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  width: 100%;
+  max-width: 860px;
+  display: flex;
+  flex-direction: column;
+}
+
+.history-modal-header {
+  padding: 1.25rem 1.5rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.history-modal-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text);
+  flex: 1;
+}
+
+.history-modal-close {
+  margin-left: auto;
+}
+
+.history-modal-body {
+  padding: 1.25rem 1.5rem;
+  font-size: 0.875rem;
+  color: var(--text);
+  max-height: calc(100vh - 10rem);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.history-loading,
+.history-empty {
+  color: var(--text-muted);
+  text-align: center;
+  padding: 2rem 0;
+}
+
+.history-error {
+  color: #f87171;
+  text-align: center;
+  padding: 2rem 0;
+}
+
+.history-entry {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.history-entry-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+}
+
+/* Flatten code blocks into the history entry container */
+.history-entry pre {
+  border: none;
+  border-radius: 0;
+  margin: 0;
+  padding: 0;
+  max-height: 280px;
+  background: #0d1117;
+}
+
+.history-entry pre code {
+  padding: 0.75rem 1rem;
+  display: block;
+}
+
+.history-entry pre.diff-block {
+  padding: 0.75rem 1rem;
+}
+
+.history-entry .file-path {
+  padding: 0.5rem 1rem 0;
+  background: #0d1117;
+  margin: 0;
+}
+
+.history-entry .git-commit-block,
+.history-entry .two-part-block {
+  padding: 0.75rem 1rem;
+  background: #0d1117;
+}
+
+.history-entry .git-commit-block pre,
+.history-entry .two-part-block pre {
+  padding: 0.5rem 0;
+  background: transparent;
+}
+
+.history-entry .commit-message {
+  padding: 0.5rem 0 0;
+}
+
+.history-entry-time {
+  margin-left: auto;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.history-entry-source {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.15em 0.5em;
+  border-radius: 3px;
+}
+
+.history-source-auto {
+  background: var(--border);
+  color: var(--text-muted);
+}
+
+.history-source-approved {
+  background: #16a34a33;
+  color: #4ade80;
+}
+
+.btn-history {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+}
+
+.btn-history:hover {
+  border-color: var(--text-muted);
+  color: var(--text);
+}
+
+.btn-hide-reviewed {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  padding: 0.2em 0.6em;
+}
+
+.btn-hide-reviewed:hover {
+  border-color: var(--text-muted);
+  color: var(--text);
+}
+
+.btn-mark-reviewed {
+  margin-left: auto;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  padding: 0.1em 0.4em;
+  border-radius: 3px;
+  opacity: 0.4;
+}
+
+.btn-mark-reviewed:hover,
+.btn-mark-reviewed.is-reviewed {
+  opacity: 1;
+  border-color: #16a34a88;
+  color: #4ade80;
+}
+
+.history-entry.is-reviewed {
+  opacity: 0.45;
+}
+
+.btn-link {
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: var(--text-muted);
+  text-decoration: underline;
+  cursor: pointer;
+  font-size: inherit;
+}
+
+.btn-link:hover {
+  color: var(--text);
+}
+
 .btn-approve-plan {
   background: #16a34a;
   color: #fff;

--- a/frontend/app/utils/ui-types.ts
+++ b/frontend/app/utils/ui-types.ts
@@ -28,6 +28,14 @@ export interface QueueItem {
   _old_content?: string;
 }
 
+export interface RunLogEntry {
+  timestamp: number;
+  session_id: string;
+  tool_name: string;
+  tool_input: unknown;
+  source: 'approved' | 'auto';
+}
+
 export interface AskOption {
   label: string;
   description?: string;

--- a/src/routes.test.ts
+++ b/src/routes.test.ts
@@ -607,30 +607,58 @@ describe("GET /log", () => {
     expect(body).toEqual([]);
   });
 
-  test("log grows as items are enqueued", async () => {
-    const pendingRes = fetch(`http://localhost:${server.port}/pending`, {
+  test("log grows when PostToolUse fires (auto source)", async () => {
+    await fetch(`http://localhost:${server.port}/post-tool-use`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ tool_name: "Bash", tool_input: { command: "ls" }, session_id: "s1" }),
     });
-    await Bun.sleep(10);
 
     const res = await fetch(`http://localhost:${server.port}/log`);
-    const body = (await res.json()) as { tool_name: string }[];
+    const body = (await res.json()) as { tool_name: string; source: string; session_id: string }[];
     expect(body).toHaveLength(1);
     expect(body[0].tool_name).toBe("Bash");
+    expect(body[0].source).toBe("auto");
+    expect(body[0].session_id).toBe("s1");
+  });
 
-    // Resolve via queue to clean up
-    const queueRes = await fetch(`http://localhost:${server.port}/queue`);
-    const queue = (await queueRes.json()) as { id: string }[];
-    if (queue.length > 0) {
-      await fetch(`http://localhost:${server.port}/decide/${queue[0].id}`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ decision: "allow" }),
-      });
-    }
+  test("source is 'approved' when PostToolUse clears a pending entry", async () => {
+    const pendingRes = fetch(`http://localhost:${server.port}/pending`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ tool_name: "Bash", tool_input: { command: "echo hi" }, session_id: "s2" }),
+    });
+    await Bun.sleep(10);
+
+    await fetch(`http://localhost:${server.port}/post-tool-use`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ tool_name: "Bash", tool_input: { command: "echo hi" }, session_id: "s2" }),
+    });
     await pendingRes;
+
+    const res = await fetch(`http://localhost:${server.port}/log`);
+    const body = (await res.json()) as { source: string; session_id: string }[];
+    expect(body).toHaveLength(1);
+    expect(body[0].source).toBe("approved");
+  });
+
+  test("session_id filter returns only matching entries", async () => {
+    await fetch(`http://localhost:${server.port}/post-tool-use`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ tool_name: "Bash", tool_input: { command: "ls" }, session_id: "sessA" }),
+    });
+    await fetch(`http://localhost:${server.port}/post-tool-use`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ tool_name: "Write", tool_input: { path: "/tmp/x" }, session_id: "sessB" }),
+    });
+
+    const res = await fetch(`http://localhost:${server.port}/log?session_id=sessA`);
+    const body = (await res.json()) as { session_id: string }[];
+    expect(body).toHaveLength(1);
+    expect(body[0].session_id).toBe("sessA");
   });
 });
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -128,6 +128,7 @@ export function createRoutes(
         const sessionId = asString(payload.session_id);
         const toolName = asString(payload.tool_name);
 
+        let matched = false;
         const toolInput = stableStringify(payload.tool_input);
         for (const [id, entry] of pending) {
           if (
@@ -135,6 +136,7 @@ export function createRoutes(
             entry.payload.tool_name === toolName &&
             stableStringify(entry.payload.tool_input) === toolInput
           ) {
+            matched = true;
             logRemoval(id, "post-tool-use", entry);
             pending.delete(id);
             notifySwiftBar(pending.size + idleSessions.size);
@@ -142,6 +144,15 @@ export function createRoutes(
             break;
           }
         }
+
+        log.push({
+          timestamp: Date.now(),
+          session_id: sessionId,
+          tool_name: toolName,
+          tool_input: payload.tool_input,
+          source: matched ? "approved" : "auto",
+        });
+        if (log.length > LOG_MAX) log.splice(0, log.length - LOG_MAX);
 
         return Response.json({ ok: true });
       },
@@ -333,8 +344,9 @@ export function createRoutes(
     },
 
     "/log": {
-      GET() {
-        return Response.json(log);
+      GET(req: Request) {
+        const sid = new URL(req.url).searchParams.get("session_id");
+        return Response.json(sid ? log.filter((e) => e.session_id === sid) : log);
       },
     },
 
@@ -403,13 +415,6 @@ export function createRoutes(
           });
         }
         const toolName = asString(payload.tool_name, "unknown");
-        log.push({
-          id,
-          timestamp: Date.now(),
-          tool_name: toolName,
-          tool_input: payload.tool_input,
-        });
-        if (log.length > LOG_MAX) log.splice(0, log.length - LOG_MAX);
         const summary = JSON.stringify(payload.tool_input ?? "");
         console.log(`[enqueue] ${toolName} | ${summary.slice(0, 120)} | id=${id}`);
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -6,13 +6,16 @@ export const IDLE_SESSION_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 export const pendingRequests = new Map<string, PendingEntry>();
 export const idleSessions = new Map<string, IdleSession>();
 
-export const LOG_MAX = 200;
+export const LOG_MAX = 1000;
+
+export type LogEntrySource = "approved" | "auto";
 
 export interface LogEntry {
-  id: string;
   timestamp: number;
+  session_id: string;
   tool_name: string;
   tool_input: unknown;
+  source: LogEntrySource;
 }
 
 export const payloadLog: LogEntry[] = [];


### PR DESCRIPTION
## Summary

- Adds a **Session History** modal to idle session cards, showing all tool calls executed in that session (sourced from `PostToolUse`)
- Log entries carry a `source` field: `approved` (cleared a pending approval) or `auto` (ran without intervention)
- `GET /log` now accepts `?session_id=` for per-session filtering
- `LOG_MAX` raised from 200 → 1000

## Key design decisions

**Executed tools only** — denied and timed-out tools are not logged; they never ran. This is intentional for a "session history" view.

**Modal owned by `IdleSessions`**, not `IdleSessionCard` — prevents the modal from disappearing if the session resumes or is dismissed while the user is reviewing history.

**Reviewed state in localStorage** (`cas:reviewed`) — each entry has a ✓ button to mark it reviewed. A "Hide/Show reviewed (N)" toggle appears in the modal header once any entry is marked. Persists across page reloads.

## Test plan

- [ ] Open history modal on an idle session — entries appear newest-first
- [ ] `source` badge shows "Auto" or "Approved" correctly
- [ ] Mark an entry reviewed — ✓ turns green, entry dims
- [ ] Toggle "Hide reviewed" — reviewed entries disappear; "Show reviewed" restores them
- [ ] Reload page — reviewed state persists
- [ ] Dismiss the idle session while history modal is open — modal stays visible
- [ ] Session resumes (new tool call) while history modal is open — modal stays visible
- [ ] Network error loading history — "Failed to load history." shown instead of empty state
- [ ] `bun test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)